### PR TITLE
U 替换 webpackChunk 备注为等长空格

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,11 @@ const { mappings, rootpath: rootfile, allowedsuffix } = vscode.workspace.getConf
  * @returns 目标路径
  */
 const screeningPath = function (linetext, position) {
+    let webpackChunkReg = /(\/\* webpackChunkName: .+ \*\/)/g; // 替换 webpackChunk 备注为等长空格
+    linetext = linetext.replace(webpackChunkReg, function (str, p1) {
+      let remainStr = str.replace(webpackChunkReg, '');
+      return new Array(p1.length).fill(' ').join('') + remainStr;
+    });
     let c = /('.+')|(".+")/;
     let arr = linetext.match(c);
     if (arr) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-alias-skip",
   "displayName": "别名路径跳转",
   "description": "别名路径跳转插件，支持任何项目，可以自由配置映射规则，自由配置可缺省后缀名列表",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "engines": {
     "vscode": "^1.30.0"
   },


### PR DESCRIPTION
1. 插件原本仅获取第一个双引号或单引号包裹的内容；
2. 遇到 webpackChunk 备注，获取到的是分包名；不符合预期；
3. 添加 webpackChunk 注释格式的替换，以便简单跳转到对应文件；

![alias-skip](https://user-images.githubusercontent.com/31369318/179052992-1f344b10-8389-4c37-91ba-81e2ab60d233.gif)